### PR TITLE
Include submodules to ensure all packages are present

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
+      with:
+        submodules: true
     - uses: actions/setup-python@v6
       with:
         python-version: '3.14' 


### PR DESCRIPTION
Previously, submodules were not included in the checkout step of the pipeline. This caused the stint_tracker process to fail, as it was missing a critical module.